### PR TITLE
renamed 'include' to 'link' in the name of stylesheet tag method 

### DIFF
--- a/lib/twitter-bootstrap-rails-cdn.rb
+++ b/lib/twitter-bootstrap-rails-cdn.rb
@@ -28,7 +28,7 @@ module TwitterBootstrap::Rails::Cdn
       end
     end
 
-    def twitter_bootstrap_stylesheet_include_tag(host, options = {}, html_options = {})
+    def twitter_bootstrap_stylesheet_link_tag(host, options = {}, html_options = {})
       local = twitter_bootstrap_stylesheet_url(:local, options)
 
       if OFFLINE and !options[:force]


### PR DESCRIPTION
Thanks for the handy gem!  I always prefer to use CDN when I can.

In the README documentation the stylesheet tag method is named:

_twitter_bootstrap_stylesheet_link_tag_

However, in the code it is named:

_twitter_bootstrap_stylesheet_include_tag_

I agree with the former as it is more consistent with the Rails helper method's name.
